### PR TITLE
Fix Sidekiq 8 unique jobs tab paths

### DIFF
--- a/lib/sidekiq_unique_jobs/web.rb
+++ b/lib/sidekiq_unique_jobs/web.rb
@@ -66,7 +66,7 @@ begin
       SidekiqUniqueJobs::Web,
       name: "unique_jobs",
       tab: ["Locks"],
-      index: %w[locks/],
+      index: %w[locks],
     )
   end
 rescue NameError, LoadError => ex

--- a/spec/sidekiq_unique_jobs/web_spec.rb
+++ b/spec/sidekiq_unique_jobs/web_spec.rb
@@ -36,6 +36,18 @@ RSpec.describe SidekiqUniqueJobs::Web do
   let(:lock_info)  { { "type" => "until_executed" } }
   let(:digests)    { SidekiqUniqueJobs::Digests.new }
 
+  it "registers the locks tab without a trailing slash" do
+    expect(Sidekiq::Web.tabs.fetch("Locks")).to eq("locks")
+  end
+
+  it "renders the locks navigation without a trailing slash" do
+    get "/"
+
+    expect(last_response).to be_ok
+    expect(last_response.body).to include('href="/locks"')
+    expect(last_response.body).not_to include('href="/locks/"')
+  end
+
   it "can display locks" do
     lock_one.lock(jid_one, lock_info)
     lock_two.lock(jid_two, lock_info)


### PR DESCRIPTION
This fixes the Sidekiq 8 web tab registration for `sidekiq-unique-jobs`.

The extension currently registers the `Locks` tab index as `locks/`, but the web extension route is defined as `/locks`. Sidekiq Web matches static routes exactly, so the navigation renders a trailing-slash URL that falls through to `404 Not Found`.

This change updates the registered index path to `locks` and adds regression coverage (let me know if this adds to many tests).

Note: I hit this when running Sidekiq Web as a standalone rack app, not sure if the same issue exists in other environments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed trailing slash in the "Locks" tab navigation path for cleaner, more standard URLs.

* **Tests**
  * Added validation tests to ensure the "Locks" tab and navigation render without trailing slashes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mhenrixon/sidekiq-unique-jobs/pull/961)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->